### PR TITLE
Update composer.json to allow for PHP 8.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": ">=7.0",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-json": "*"


### PR DESCRIPTION
I'm upgrading a project to use PHP 8.0.1 and would like to continue using video-platforms-parser. This is a small change to update the allowed version of PHP in composer.json.